### PR TITLE
Allow users to specify custom ssh port

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Example playbook:
 
 ~~~ yaml my-site.yml
 ssh_url: admin@example.com
+ssh_port: 22  # Optional (default: 22)
 
 # List of modules to execute
 modules:

--- a/libexec/priv/run-ssh-script
+++ b/libexec/priv/run-ssh-script
@@ -4,12 +4,13 @@
 # to automatically enter sudo passwords for the user.
 #
 set url [lindex $argv 0];
-set command [lindex $argv 1];
-set sudo_pass [lindex $argv 2];
+set ssh_port [lindex $argv 1];
+set command [lindex $argv 2];
+set sudo_pass [lindex $argv 3];
 
 set timeout -1
 
-spawn -noecho ssh -t $url $command
+spawn -noecho ssh -t $url -p $ssh_port $command
 expect -exact "\[sudo\] password for "
 send -- "$sudo_pass\r"
 interact

--- a/libexec/welder-cleanup
+++ b/libexec/welder-cleanup
@@ -14,6 +14,6 @@ playbook=$1
 
 __load_config "$playbook.yml"
 
-ssh $cfg_ssh_url "rm -r setup/"
+ssh $cfg_ssh_url -p $cfg_ssh_port "rm -r setup/"
 
 __success "setup/ directory removed from $cfg_ssh_url"

--- a/libexec/welder-compile
+++ b/libexec/welder-compile
@@ -45,6 +45,6 @@ fi
 __info "uploading template files to the server"
 
 # rsync compiled files to the server, skipping source (liquid) templates
-rsync -a --delete --exclude="*.liquid" $tmp_dir/ $cfg_ssh_url:setup
+rsync -a -e "ssh -p $cfg_ssh_port" --delete --exclude="*.liquid" $tmp_dir/ $cfg_ssh_url:setup
 
 __success "uploading template files to the server"

--- a/libexec/welder-run
+++ b/libexec/welder-run
@@ -11,7 +11,8 @@ playbook=$1
 
 __load_config "$playbook.yml"
 
-[ -z "$cfg_ssh_url" ] && __fail "ssh_url variable must be set in $playbook.yml"
+[ -z "${cfg_ssh_url}" ] && __fail "ssh_url variable must be set in $playbook.yml"
+if [ -z "${cfg_ssh_port}" ]; then cfg_ssh_port="22"; fi
 [ ! -d ./modules ]    && __fail "no modules/ directory found"
 
 # Run all *.sh scripts for each module listed in $playbook
@@ -29,11 +30,11 @@ function __run_scripts() {
       if [ -z ${sudo_pass+x} ]
       then
         # no sudo_pass set, run the script directly
-        ssh -t "$cfg_ssh_url" "$(< $script)"
+        ssh -t "$cfg_ssh_url" -p "$cfg_ssh_port" "$(< $script)"
       else
         # wrap the ssh script with an "expect" script to automatically
         # enter sudo password
-        $WELDER_ROOT/libexec/priv/run-ssh-script "$cfg_ssh_url" "$(< $script)" $sudo_pass
+        $WELDER_ROOT/libexec/priv/run-ssh-script "$cfg_ssh_url" "$cfg_ssh_port" "$(< $script)" $sudo_pass
       fi
 
       echo

--- a/libexec/welder-run-script
+++ b/libexec/welder-run-script
@@ -14,8 +14,9 @@ __load_config "$playbook.yml"
 
 [ -z "$playbook" ]       && __fail "Usage: x run-script <playbook-name>"
 [ ! -f ./$playbook.yml ] && __fail "No $playbook.yml file found"
-[ -z "$cfg_ssh_url" ]    && __fail "ssh_url variable must be set in $playbook.yml"
+[ -z "${cfg_ssh_url}" ]  && __fail "ssh_url variable must be set in $playbook.yml"
+if [ -z "${cfg_ssh_port}" ]; then cfg_ssh_port="22"; fi
 
-ssh -t "$cfg_ssh_url" "$(< $script)"
+ssh -t "$cfg_ssh_url" -p "$cfg_ssh_port" "$(< $script)"
 
 __success "done!"


### PR DESCRIPTION
Adds an optional  parameter __ssh_port__ which you can add along with __ssh_url__ when you have it running on a different port. Defaults to port _22_. Fixes #3 