### PR TITLE
v0.0.5: Minor fixes

### DIFF
--- a/libexec/priv/_helpers
+++ b/libexec/priv/_helpers
@@ -1,19 +1,23 @@
 #!/bin/bash
 
 function __info () {
-  printf "  [ \033[00;34m..\033[0m ] $1"
+  # Author of changes: trimstray (contact@nslab.at)
+  printf "  [ \033[00;34m..\033[0m ] %s" "$1"
 }
 
 function __success () {
-  printf "\r\033[2K  [ \033[00;32mOK\033[0m ] $1\n"
+  # Author of changes: trimstray (contact@nslab.at)
+  printf "\r\033[2K  [ \033[00;32mOK\033[0m ] %s\n" "$1"
 }
 
 function __user () {
-  printf "\r  [ \033[0;33m?\033[0m ] $1 "
+  # Author of changes: trimstray (contact@nslab.at)
+  printf "\r  [ \033[0;33m?\033[0m ] %s" "$1"
 }
 
 function __fail () {
-  printf "\r\033[2K  [\033[0;31mFAIL\033[0m] $1\n"
+  # Author of changes: trimstray (contact@nslab.at)
+  printf "\r\033[2K  [\033[0;31mFAIL\033[0m] %s\n" "$1"
   echo ''
   exit 1
 }

--- a/libexec/priv/_helpers
+++ b/libexec/priv/_helpers
@@ -30,11 +30,13 @@ function __ensure_rsync() {
 }
 
 function __load_config() {
-  [ ! -f ./$1 ] && __fail "No $1 file found"
+  # Author of changes: trimstray (contact@nslab.at)
+  [ ! -f "./$1" ] && __fail "No $1 file found"
 
   # seems to fail with process substitution in bash, e.g.:
   #     source <($WELDER_ROOT/libexec/priv/parse-config $1)
-  source /dev/stdin <<< "$(cat <($WELDER_ROOT/libexec/priv/parse-config ./$1))"
+  # Author of changes: trimstray (contact@nslab.at)
+  source /dev/stdin <<< "$(cat <("${WELDER_ROOT}/libexec/priv/parse-config" "./$1"))"
 
   if [ -z "${cfg_ssh_url-}" ];  then __fail "ssh_url variable must be set in $playbook.yml"; fi
   if [ -z "${cfg_ssh_port-}" ]; then cfg_ssh_port="22"; fi

--- a/libexec/welder
+++ b/libexec/welder
@@ -28,7 +28,7 @@ export WELDER_ROOT
 # shellcheck disable=SC1090
 source "${WELDER_ROOT}/libexec/priv/_helpers"
 
-bin_path="$(abs_dirname $0)"
+bin_path="$(abs_dirname "${0}")"
 export PATH="${bin_path}:${PATH}"
 
 command=$1

--- a/libexec/welder
+++ b/libexec/welder
@@ -12,7 +12,10 @@ abort() {
 }
 
 abs_dirname() {
-  local path="$(realpath "$1")"
+  # Author of changes: trimstray (contact@nslab.at)
+  # Declare first without assign for avoid masking return values.
+  local path
+  path="$(realpath "$1")"
   echo "${path%/*}"
 }
 

--- a/libexec/welder
+++ b/libexec/welder
@@ -20,10 +20,13 @@ abs_dirname() {
 }
 
 WELDER_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-WELDER_ROOT="$(abs_dirname $WELDER_ROOT)"
+WELDER_ROOT="$(abs_dirname "${WELDER_ROOT}")"
 export WELDER_ROOT
 
-source $WELDER_ROOT/libexec/priv/_helpers
+# Author of changes: trimstray (contact@nslab.at)
+# We are not able to determine the value of the WELDER_ROOT variable so:
+# shellcheck disable=SC1090
+source "${WELDER_ROOT}/libexec/priv/_helpers"
 
 bin_path="$(abs_dirname $0)"
 export PATH="${bin_path}:${PATH}"

--- a/libexec/welder
+++ b/libexec/welder
@@ -28,6 +28,7 @@ export WELDER_ROOT
 # shellcheck disable=SC1090
 source "${WELDER_ROOT}/libexec/priv/_helpers"
 
+# Author of changes: trimstray (contact@nslab.at)
 bin_path="$(abs_dirname "${0}")"
 export PATH="${bin_path}:${PATH}"
 

--- a/libexec/welder-cleanup
+++ b/libexec/welder-cleanup
@@ -3,6 +3,11 @@
 # Removes compiled files from the server
 #
 
+# Author of changes: trimstray (contact@nslab.at)
+# Declare first before used it.
+cfg_ssh_url=""
+cfg_ssh_port=""
+
 [ -n "$DEBUG" ] && set -v
 
 set -eu

--- a/libexec/welder-cleanup
+++ b/libexec/welder-cleanup
@@ -7,7 +7,10 @@
 
 set -eu
 
-source $WELDER_ROOT/libexec/priv/_helpers
+# Author of changes: trimstray (contact@nslab.at)
+# We are not able to determine the value of the WELDER_ROOT variable so:
+# shellcheck disable=SC1090
+source "${WELDER_ROOT}/libexec/priv/_helpers"
 
 playbook=$1
 [ -z "$playbook" ] && __fail "Usage: x cleanup <playbook-name>"

--- a/libexec/welder-cleanup
+++ b/libexec/welder-cleanup
@@ -17,6 +17,7 @@ playbook=$1
 
 __load_config "$playbook.yml"
 
-ssh $cfg_ssh_url -p $cfg_ssh_port "rm -r setup/"
+# Author of changes: trimstray (contact@nslab.at)
+ssh "$cfg_ssh_url" -p "$cfg_ssh_port" "rm -r setup/"
 
 __success "setup/ directory removed from $cfg_ssh_url"

--- a/libexec/welder-compile
+++ b/libexec/welder-compile
@@ -71,6 +71,7 @@ __info "uploading template files to the server"
 
 # rsync compiled files to the server, skipping source (liquid) templates
 # Author of changes: trimstray (contact@nslab.at)
+# shellcheck disable=SC2154
 rsync -a -e "ssh -p $cfg_ssh_port" --delete --exclude="*.liquid" "${tmp_dir}/" "${cfg_ssh_url}:setup"
 
 __success "uploading template files to the server"

--- a/libexec/welder-compile
+++ b/libexec/welder-compile
@@ -19,49 +19,58 @@ __ensure_rsync
 __load_config "$playbook.yml"
 
 tmp_dir=$(pwd)/tmp/setup
-mkdir -p $tmp_dir
+# Author of changes: trimstray (contact@nslab.at)
+mkdir -p "$tmp_dir"
 rm -rf $tmp_dir/*
 
 # rsyncs only the modules that include files/ directories
 # skips setup.sh scripts and creates list of files to be compiled
 # and uploaded to the server
 function __rsync_modules() {
-  rsync -av --prune-empty-dirs --include="*/" --include="modules/*/files/**" --exclude='*' ./modules $tmp_dir
+  # Author of changes: trimstray (contact@nslab.at)
+  rsync -av --prune-empty-dirs --include="*/" --include="modules/*/files/**" --exclude='*' ./modules "$tmp_dir"
 }
 
 # Copy all "files" directories to ./tmp so they can be parsed
 if [ -z "${cfg_shared_path-}" ]; then
   echo # do nothing
 else
-  cd $cfg_shared_path && __rsync_modules && cd -
+  # Author of changes: trimstray (contact@nslab.at)
+  cd "$cfg_shared_path" && __rsync_modules && cd -
 fi
 
 __rsync_modules
 
 # Compile templates (if there's any *.liquid files)
-if test -n "$(find $tmp_dir -name '*.liquid' -print -quit)"
+# Author of changes: trimstray (contact@nslab.at)
+if test -n "$(find "$tmp_dir" -name '*.liquid' -print -quit)"
 then
   __info "compiling *.liquid templates"
-  $WELDER_ROOT/libexec/priv/compile-templates $tmp_dir
+  # Author of changes: trimstray (contact@nslab.at)
+  "${WELDER_ROOT}/libexec/priv/compile-templates" "$tmp_dir"
   __success "compiled templates"
 fi
 
 # Compile yaml config files into shell-compatible variables
-[ -f $tmp_dir/config-variables ] && rm $tmp_dir/config-variables
+# Author of changes: trimstray (contact@nslab.at)
+[ -f "${tmp_dir}/config-variables" ] && rm "${tmp_dir}/config-variables"
 
 if [ -f "./config.yml" ]
 then
-  $WELDER_ROOT/libexec/priv/parse-config "./config.yml" > $tmp_dir/config-variables
+  # Author of changes: trimstray (contact@nslab.at)
+  "${WELDER_ROOT}/libexec/priv/parse-config" "./config.yml" > "${tmp_dir}/config-variables"
 fi
 
 if [ -f "./vault.yml" ]
 then
-  $WELDER_ROOT/libexec/priv/parse-config "./vault.yml" >> $tmp_dir/config-variables
+  # Author of changes: trimstray (contact@nslab.at)
+  "${WELDER_ROOT}/libexec/priv/parse-config" "./vault.yml" >> "${tmp_dir}/config-variables"
 fi
 
 __info "uploading template files to the server"
 
 # rsync compiled files to the server, skipping source (liquid) templates
-rsync -a -e "ssh -p $cfg_ssh_port" --delete --exclude="*.liquid" $tmp_dir/ $cfg_ssh_url:setup
+# Author of changes: trimstray (contact@nslab.at)
+rsync -a -e "ssh -p $cfg_ssh_port" --delete --exclude="*.liquid" "${tmp_dir}/" "${cfg_ssh_url}:setup"
 
 __success "uploading template files to the server"

--- a/libexec/welder-compile
+++ b/libexec/welder-compile
@@ -21,7 +21,10 @@ __load_config "$playbook.yml"
 tmp_dir=$(pwd)/tmp/setup
 # Author of changes: trimstray (contact@nslab.at)
 mkdir -p "$tmp_dir"
-rm -rf $tmp_dir/*
+# Author of changes: trimstray (contact@nslab.at)
+# The command to fail if the variable is null or unset.
+# The following code prevents deleting the / directory.
+rm -rf "${tmp_dir:?}/"*
 
 # rsyncs only the modules that include files/ directories
 # skips setup.sh scripts and creates list of files to be compiled

--- a/libexec/welder-compile
+++ b/libexec/welder-compile
@@ -7,7 +7,10 @@
 
 set -eu
 
-source $WELDER_ROOT/libexec/priv/_helpers
+# Author of changes: trimstray (contact@nslab.at)
+# We are not able to determine the value of the WELDER_ROOT variable so:
+# shellcheck disable=SC1090
+source "${WELDER_ROOT}/libexec/priv/_helpers"
 
 playbook=$1
 [ -z "$playbook" ] && __fail "Usage: x compile <playbook-name>"

--- a/libexec/welder-help
+++ b/libexec/welder-help
@@ -6,4 +6,3 @@ echo "Subcommands:"
 echo "    run      run scripts on the server"
 echo "    version  welder version"
 echo ""
-

--- a/libexec/welder-run
+++ b/libexec/welder-run
@@ -70,7 +70,11 @@ welder compile "$playbook"
 if [[ ! "$cfg_ssh_url" =~ root\@.* ]]
 then
   __user "what's the sudo password for $cfg_ssh_url: "
-  read -se sudo_pass
+  # Author of changes: trimstray (contact@nslab.at)
+  # Added -r opt to read because:
+  #   - we want strip leading and trailing spaces
+  #   - we want to read data without removing backslashes before spaces and line feeds
+  read -rse sudo_pass
 fi
 
 __run_scripts

--- a/libexec/welder-run
+++ b/libexec/welder-run
@@ -36,18 +36,21 @@ function __run_scripts() {
       fi
     fi
 
-    for script in $(find $module_path -name "*.sh")
+    # Author of changes: trimstray (contact@nslab.at)
+    for script in $(find "$module_path" -name "*.sh")
     do
       __info "script $script\n"
 
-      if [ -z ${sudo_pass+x} ]
+      # Author of changes: trimstray (contact@nslab.at)
+      if [ -z "${sudo_pass+x}" ]
       then
         # no sudo_pass set, run the script directly
         ssh -t "$cfg_ssh_url" -p "$cfg_ssh_port" "$(< $script)"
       else
         # wrap the ssh script with an "expect" script to automatically
         # enter sudo password
-        $WELDER_ROOT/libexec/priv/run-ssh-script "$cfg_ssh_url" "$cfg_ssh_port" "$(< $script)" $sudo_pass
+        # Author of changes: trimstray (contact@nslab.at)
+        "${WELDER_ROOT}/libexec/priv/run-ssh-script" "$cfg_ssh_url" "$cfg_ssh_port" "$(< $script)" "$sudo_pass"
       fi
 
       echo
@@ -58,11 +61,13 @@ function __run_scripts() {
   done
 }
 
-welder compile $playbook
+# Author of changes: trimstray (contact@nslab.at)
+welder compile "$playbook"
 
 # Ask sudo password for non-root users
 # For this to work, ssh_url needs to follow user@server-url format
-if [[ ! $cfg_ssh_url =~ root\@.* ]]
+# Author of changes: trimstray (contact@nslab.at)
+if [[ ! "$cfg_ssh_url" =~ root\@.* ]]
 then
   __user "what's the sudo password for $cfg_ssh_url: "
   read -se sudo_pass
@@ -70,6 +75,7 @@ fi
 
 __run_scripts
 
-welder cleanup $playbook
+# Author of changes: trimstray (contact@nslab.at)
+welder cleanup "$playbook"
 
 __success "all done!"

--- a/libexec/welder-run
+++ b/libexec/welder-run
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Author of changes: trimstray (contact@nslab.at)
+# Declare first before used it.
+cfg_modules=""
+
 [ -n "$DEBUG" ] && set -v
 
 set -eu

--- a/libexec/welder-run
+++ b/libexec/welder-run
@@ -4,7 +4,10 @@
 
 set -eu
 
-source $WELDER_ROOT/libexec/priv/_helpers
+# Author of changes: trimstray (contact@nslab.at)
+# We are not able to determine the value of the WELDER_ROOT variable so:
+# shellcheck disable=SC1090
+source "${WELDER_ROOT}/libexec/priv/_helpers"
 
 playbook=$1
 [ -z "$playbook" ] && __fail "Usage: x run <playbook-name>"

--- a/libexec/welder-run-script
+++ b/libexec/welder-run-script
@@ -11,7 +11,8 @@ playbook=$1
 script=$2
 
 [ -z "$playbook" ]       && __fail "Usage: x run-script <playbook-name>"
-[ ! -f ./$playbook.yml ] && __fail "No $playbook.yml file found"
+# Author of changes: trimstray (contact@nslab.at)
+[ ! -f "./${playbook}.yml" ] && __fail "No $playbook.yml file found"
 
 __load_config "$playbook.yml"
 


### PR DESCRIPTION
I fixed some warning/critical bugs:
- added double quote (variables) [**warning**]
- declare first without assign (variables) [**warning**]
- prevents deleting the / directory [**critical**]
- added `-r` opt to read command [**warning**]
- moved `$1` variable outside printf format string [**warning**]

New tag: **v0.0.5**