### PR TITLE
Some adjustments

### DIFF
--- a/libexec/priv/_helpers
+++ b/libexec/priv/_helpers
@@ -25,12 +25,23 @@ function __ensure_rsync() {
 }
 
 function __load_config() {
-  [ ! -f "$1" ] && __fail "No $1 file found"
+  [[ $# != 1 ]] && return 1
 
-  # seems to fail with process substitution in bash, e.g.:
-  #     source <($WELDER_ROOT/libexec/priv/parse-config $1)
-  source /dev/stdin <<< "$(cat <($WELDER_ROOT/libexec/priv/parse-config "$1"))"
+  local playbook=${WELDER_PLAYBOOK:-}
+  if [[ -z "$playbook" ]]; then
+    for playbook in "$1" "$WELDER_ROOT/$1" "$WELDER_ROOT/$1.yml" "$WELDER_ROOT/$1.yaml"; do
+      if [[ -e "$playbook" ]]; then
+        export WELDER_PLAYBOOK="$(mktemp -p "$WELDER_CACHE" playbook.XXXXXXXXXX)"
+        trap 'unlink "$WELDER_PLAYBOOK"' EXIT
+        cp "$playbook" "$WELDER_PLAYBOOK"
+        break
+      fi
+    done
+  fi
+  [[ -z "${WELDER_PLAYBOOK:-}" ]] && return 1
 
-  if [ -z "${cfg_ssh_url-}" ];  then __fail "ssh_url variable must be set in $1"; fi
+  eval "$($WELDER_ROOT/libexec/priv/parse-config "$WELDER_PLAYBOOK")"
+
+  if [ -z "${cfg_ssh_url-}" ]; then __fail "variable not set in playbook: ssh_url"; fi
   if [ -z "${cfg_ssh_port-}" ]; then cfg_ssh_port="22"; fi
 }

--- a/libexec/priv/_helpers
+++ b/libexec/priv/_helpers
@@ -21,7 +21,6 @@ function __fail () {
 function __ensure_rsync() {
   if ! command -v rsync > /dev/null; then
     __fail "Please install rsync first"
-    exit 1
   fi
 }
 

--- a/libexec/welder
+++ b/libexec/welder
@@ -11,8 +11,10 @@ abort() {
   exit 1
 }
 
-WELDER_ROOT="$( cd "$( dirname "$( readlink ${BASH_SOURCE[0]} )" )/.." && pwd )"
-export WELDER_ROOT
+export WELDER_ROOT="$( cd "$( dirname "$( readlink ${BASH_SOURCE[0]} )" )/.." && pwd )"
+
+export WELDER_CACHE="${XDG_CACHE_HOME:-$HOME/.cache}/${0##*/}"
+mkdir -p "$WELDER_CACHE"
 
 source "$WELDER_ROOT/libexec/priv/_helpers"
 

--- a/libexec/welder-cleanup
+++ b/libexec/welder-cleanup
@@ -9,10 +9,7 @@ set -eu
 
 source $WELDER_ROOT/libexec/priv/_helpers
 
-playbook=$1
-[ -z "$playbook" ] && __fail "Usage: x cleanup <playbook-name>"
-
-__load_config "$WELDER_ROOT/$playbook.yml"
+__load_config "$@" || __fail "Usage: welder cleanup <playbook>"
 
 ssh $cfg_ssh_url -p $cfg_ssh_port "rm -r setup/"
 

--- a/libexec/welder-compile
+++ b/libexec/welder-compile
@@ -9,11 +9,9 @@ set -eu
 
 source $WELDER_ROOT/libexec/priv/_helpers
 
-playbook=$1
-[ -z "$playbook" ] && __fail "Usage: x compile <playbook-name>"
+__load_config "$@" || __fail "Usage: welder compile <playbook>"
 
 __ensure_rsync
-__load_config "$WELDER_ROOT/$playbook.yml"
 
 tmp_dir=$(mktemp -d)
 trap 'rm -rf "$tmp_dir"' EXIT

--- a/libexec/welder-run
+++ b/libexec/welder-run
@@ -6,10 +6,7 @@ set -eu
 
 source $WELDER_ROOT/libexec/priv/_helpers
 
-playbook=$1
-[ -z "$playbook" ] && __fail "Usage: x run <playbook-name>"
-
-__load_config "$WELDER_ROOT/$playbook.yml"
+__load_config "$@" || __fail "Usage: welder run <playbook>"
 
 [ ! -d "$WELDER_ROOT/modules" ] && __fail "no modules/ directory found"
 
@@ -55,7 +52,7 @@ function __run_scripts() {
   done
 }
 
-welder compile $playbook
+welder compile "$@"
 
 # Ask sudo password for non-root users
 # For this to work, ssh_url needs to follow user@server-url format
@@ -67,6 +64,6 @@ fi
 
 __run_scripts
 
-welder cleanup $playbook
+welder cleanup "$@"
 
 __success "all done!"


### PR DESCRIPTION
Commit https://github.com/pch/welder/commit/654202997df8c1adf174a7128a9e6c0326851d67 allows that files from any directory can be taken as playbooks. However, the program remains compatible to the previous behaviour. But with these changes it is also possible to use something like ad hoc playbooks:

```shell
welder run <(echo '{ssh_url: user@host, modules: [moduleA,moduleB,moduleC]}')
```